### PR TITLE
In `_remote_tag_digest()`, treat a missing manifest digest as non-fatal.

### DIFF
--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -215,7 +215,7 @@ class Push(object):
     if resp.status == httplib.NOT_FOUND:  # pytype: disable=attribute-error
       return None
 
-    return resp['docker-content-digest']
+    return resp.get('docker-content-digest', '')
 
   def _put_manifest(self, image):
     """Upload the manifest for this image."""


### PR DESCRIPTION
ECR doesn't set this header in its response. The pusher should fall back to checking for the presence of each blob when there's no manifest digest.

Also, if you could enable Issues in the `google/containerregistry` repo, that would be easier than using Github PRs since the code is just going to get merged via g4 anyway.