### PR TITLE
Make importer save an uncompressed form for performance.

### DIFF
--- a/client/v2_2/docker_image_list_.py
+++ b/client/v2_2/docker_image_list_.py
@@ -96,6 +96,10 @@ class Platform(object):
     return target.can_run(self)
 
   def __iter__(self):
+    # Ensure architecture and os are set (for default platform).
+    self._content['architecture'] = self.architecture()
+    self._content['os'] = self.os()
+
     return iter(self._content.iteritems())
 
 

--- a/tools/fast_importer_.py
+++ b/tools/fast_importer_.py
@@ -49,7 +49,7 @@ def main():
 
   logging.info('Reading v2.2 image from tarball %r', args.tarball)
   with v2_2_image.FromTarball(args.tarball) as v2_2_img:
-    save.fast(v2_2_img, args.directory, threads=_THREADS)
+    save.uncompressed(v2_2_img, args.directory, threads=_THREADS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This re-exports our internal copy of: https://github.com/google/containerregistry/pull/28