### PR TITLE
Support .local domains over http

### DIFF
--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -415,5 +415,7 @@ def Scheme(endpoint):
   """Returns https scheme for all the endpoints except localhost."""
   if endpoint.startswith('localhost:'):
     return 'http'
+  elif re.match(r'.*\.local(?::\d{1,5})?$', endpoint):
+    return 'http'
   else:
     return 'https'


### PR DESCRIPTION
Suggest to add http as the scheme for domains that end in .local, potentially with a port number. 

Reason is that httplib2 provides its own cacerts.txt, preventing usage of self-signed certificates for HTTPS on internal domains. With the current code this leads to a issue because .local domains are forced to use HTTPS, but will then fail even if a valid (installed on host&client) certificate is present, because httplib2 will not have this as part of its default list in cacerts.txt

Happy to discuss

