### PR TITLE
[WIP] Add SSL Certificate Support to Fast Pull and Push

### DIFF
--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -45,7 +45,7 @@ parser.add_argument('--name', action='store',
 parser.add_argument('--directory', action='store',
                     help='Where to save the image\'s files.')
 
-parser.add_argument('--certificate', nargs='*', help='A comma separated ' +
+parser.add_argument('--certificates', nargs='*', help='A comma separated ' +
                     'tuple of key file, cert, and domain. (From httplib2 ' +
                     'docs) Add a key and cert that will be used for an SSL ' +
                     'connection to the specified domain. keyfile is the name ' +
@@ -64,6 +64,10 @@ def main():
     raise Exception('--name and --directory are required arguments.')
 
   transport = transport_pool.Http(httplib2.Http, size=_THREADS)
+
+  for item in args.certificates:
+    key, cert, domain = item.split(',')
+    transport.add_certificate(key, cert, domain)
 
   if '@' in args.name:
     name = docker_name.Digest(args.name)

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -65,9 +65,11 @@ def main():
 
   transport = transport_pool.Http(httplib2.Http, size=_THREADS)
 
-  for item in args.certificates:
-    key, cert, domain = item.split(',')
-    transport.add_certificate(key, cert, domain)
+  if args.certificates:
+    for item in args.certificates:
+      logging.info('Adding certificate %s', item)
+      key, cert, domain = item.split(',')
+      transport.add_certificate(key, cert, domain)
 
   if '@' in args.name:
     name = docker_name.Digest(args.name)

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -45,6 +45,13 @@ parser.add_argument('--name', action='store',
 parser.add_argument('--directory', action='store',
                     help='Where to save the image\'s files.')
 
+parser.add_argument('--certificate', nargs='*', help='A comma separated ' +
+                    'tuple of key file, cert, and domain. (From httplib2 ' +
+                    'docs) Add a key and cert that will be used for an SSL ' +
+                    'connection to the specified domain. keyfile is the name ' +
+                    'of a PEM formatted file that contains your private key. ' +
+                    'certfile is a PEM formatted certificate chain file.')
+
 _THREADS = 8
 
 

--- a/tools/fast_pusher_.py
+++ b/tools/fast_pusher_.py
@@ -130,9 +130,11 @@ def main():
 
   transport = transport_pool.Http(httplib2.Http, size=_THREADS)
 
-  for item in args.certificates:
-    key, cert, domain = item.split(',')
-    transport.add_certificate(key, cert, domain)
+  if args.certificates:
+    for item in args.certificates:
+      logging.info('Adding certificate %s', item)
+      key, cert, domain = item.split(',')
+      transport.add_certificate(key, cert, domain)
 
   # Resolve the appropriate credential to use based on the standard Docker
   # client logic.

--- a/tools/fast_pusher_.py
+++ b/tools/fast_pusher_.py
@@ -61,6 +61,13 @@ parser.add_argument('--stamp-info-file', action='append', required=False,
 parser.add_argument('--oci', action='store_true',
                     help='Push the image with an OCI Manifest.')
 
+parser.add_argument('--certificates', nargs='*', help='A comma separated ' +
+                    'tuple of key file, cert, and domain. (From httplib2 ' +
+                    'docs) Add a key and cert that will be used for an SSL ' +
+                    'connection to the specified domain. keyfile is the name ' +
+                    'of a PEM formatted file that contains your private key. ' +
+                    'certfile is a PEM formatted certificate chain file.')
+
 _THREADS = 8
 
 
@@ -122,6 +129,10 @@ def main():
     raise Exception('--digest and --layer must have matching lengths.')
 
   transport = transport_pool.Http(httplib2.Http, size=_THREADS)
+
+  for item in args.certificates:
+    key, cert, domain = item.split(',')
+    transport.add_certificate(key, cert, domain)
 
   # Resolve the appropriate credential to use based on the standard Docker
   # client logic.

--- a/transport/transport_pool_.py
+++ b/transport/transport_pool_.py
@@ -47,6 +47,18 @@ class Http(httplib2.Http):
       # We returned an item, notify a waiting thread.
       self._condition.notify(n=1)
 
+  def add_certificate(self, key, cert, domain):
+    """Adds a certificate to all of the underlying transports.
+
+    From httplib2 docs:
+
+    Add a key and cert that will be used for an SSL connection to the
+    specified domain. keyfile is the name of a PEM formatted file that contains
+    your private key. certfile is a PEM formatted certificate chain file.
+    """
+    for transport in self._transports:
+      transport.add_certificate(key, cert, domain)
+
   def request(self, *args, **kwargs):
     """This awaits a transport and delegates the request call.
 


### PR DESCRIPTION
This PR allows specifying SSL certificates (client key and cert chain) for a specific domain (or set of domains). The transport pool wrapper now exposes a `add_certificate` method that mimics the underlying httplib2.Http transports that it's wrapping.