### PR TITLE
Client insecure http scheme for .localhost endpoints

### DIFF
--- a/client/v2/docker_http_.py
+++ b/client/v2/docker_http_.py
@@ -396,7 +396,7 @@ def Scheme(endpoint):
   """Returns https scheme for all the endpoints except localhost."""
   if endpoint.startswith('localhost:'):
     return 'http'
-  elif re.match(r'.*\.local(?::\d{1,5})?$', endpoint):
+  elif re.match(r'.*\.local(?:host)?(?::\d{1,5})?$', endpoint):
     return 'http'
   else:
     return 'https'

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -427,7 +427,7 @@ def Scheme(endpoint):
   """Returns https scheme for all the endpoints except localhost."""
   if endpoint.startswith('localhost:'):
     return 'http'
-  elif re.match(r'.*\.local(?::\d{1,5})?$', endpoint):
+  elif re.match(r'.*\.local(?:host)?(?::\d{1,5})?$', endpoint):
     return 'http'
   else:
     return 'https'


### PR DESCRIPTION
This is so `docker.for.mac.localhost` works which is provided by docker to allow containers to find the hosts ip on mac.