### PR TITLE
Remove invalid proxy behavior of Http and RetryTransport

### DIFF
--- a/transport/retry_transport_.py
+++ b/transport/retry_transport_.py
@@ -62,7 +62,7 @@ class Factory(object):
     return RetryTransport(**self.kwargs)
 
 
-class RetryTransport(httplib2.Http):
+class RetryTransport:
   """A wrapper for the given transport which automatically retries errors.
   """
 

--- a/transport/transport_pool_.py
+++ b/transport/transport_pool_.py
@@ -21,7 +21,7 @@ import threading
 import httplib2
 
 
-class Http(httplib2.Http):
+class Http:
   """A threadsafe pool of httplib2.Http transports."""
 
   def __init__(self,


### PR DESCRIPTION
Unless we make a proper proxy out of Http and RetryTransport, this generates a messed up object because one part of function calls go to
self and others delegate to _transport.

So only expose methods, which really delegate.