### PR TITLE
Remove unnecessary flag

### DIFF
--- a/flatten.yaml
+++ b/flatten.yaml
@@ -2,9 +2,6 @@ steps:
 # Build the flatten PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    # TODO(user): Remove once this is released:
-    # https://github.com/GoogleCloudPlatform/cloud-builders/pull/29
-    '--output_base', '/workspace',
     'build', '//:flatten.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.


### PR DESCRIPTION
The referenced PR has been merged and released, and the build succeeds without the flag.