### PR TITLE
Improve error message when cred helper not found

### DIFF
--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -157,7 +157,7 @@ class Helper(Basic):
                            stderr=subprocess.STDOUT)
     except OSError as e:
       if e.errno == errno.ENOENT:
-        raise Exception("executable not found: %s" % bin_name)
+        raise Exception('executable not found: ' + bin_name)
       raise
 
     # Some keychains expect a scheme:

--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -18,6 +18,7 @@
 
 import abc
 import base64
+import errno
 import json
 import logging
 import os
@@ -149,10 +150,16 @@ class Helper(Basic):
 
     bin_name = 'docker-credential-{name}'.format(name=self._name)
     logging.info('Invoking %r to obtain Docker credentials.', bin_name)
-    p = subprocess.Popen([bin_name, 'get'],
-                         stdout=subprocess.PIPE,
-                         stdin=subprocess.PIPE,
-                         stderr=subprocess.STDOUT)
+    try:
+      p = subprocess.Popen([bin_name, 'get'],
+                           stdout=subprocess.PIPE,
+                           stdin=subprocess.PIPE,
+                           stderr=subprocess.STDOUT)
+    except OSError as e:
+      if e.errno == errno.ENOENT:
+        raise Exception("executable not found: %s" % bin_name)
+      raise
+
     # Some keychains expect a scheme:
     # https://github.com/bazelbuild/rules_docker/issues/111
     stdout = p.communicate(input='https://' + self._registry)[0]


### PR DESCRIPTION
This makes problems like https://github.com/bazelbuild/rules_docker/issues/196 easier to debug.
For me it happened because `puller` was run by Bazel with a restricted
PATH that didn't include `docker-credentials-gcr`. The new error in this
case is:

```
Traceback (most recent call last):
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/tools/fast_puller_.py", line 97, in <module>
    main()
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/tools/fast_puller_.py", line 83, in main
    with v2_2_image.FromRegistry(name, creds, transport, accept) as v2_2_img:
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/client/v2_2/docker_image_.py", line 364, in __enter__
    self._name, self._creds, self._original_transport, docker_http.PULL)
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/client/v2_2/docker_http_.py", line 198, in __init__
    self._Refresh()
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/client/v2_2/docker_http_.py", line 285, in _Refresh
    'Authorization': self._basic_creds.Get()
  File "/usr/local/google/home/rodrigoq/.cache/bazel/_bazel_rodrigoq/a2995359558cbf75786e44ea10657e9b/execroot/containerregistry/bazel-out/k8-fastbuild/bin/puller.runfiles/containerregistry/client/docker_creds_.py", line 160, in Get
    raise Exception("executable not found: %s" % bin_name)
Exception: executable not found: docker-credential-gcr
```