### PR TITLE
Export from mono-repo

### DIFF
--- a/appender.yaml
+++ b/appender.yaml
@@ -2,7 +2,6 @@ steps:
 # Build the puller PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    '--output_base', '/workspace',
     'build', '//:appender.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.

--- a/client/v2/docker_http_.py
+++ b/client/v2/docker_http_.py
@@ -188,16 +188,17 @@ class Transport(object):
         'content-type': 'application/json',
         'user-agent': docker_name.USER_AGENT,
     }
-    resp, unused_content = self._transport.request(
-        '{scheme}://{registry}/v2/'.format(scheme=Scheme(self._name.registry),
-                                           registry=self._name.registry),
+    resp, content = self._transport.request(
+        '{scheme}://{registry}/v2/'.format(
+            scheme=Scheme(self._name.registry), registry=self._name.registry),
         'GET',
         body=None,
         headers=headers)
 
     # We expect a www-authenticate challenge.
     _CheckState(resp.status in [httplib.OK, httplib.UNAUTHORIZED],
-                'Unexpected status: %d' % resp.status)
+                'Unexpected response pinging the registry: {}\nBody: {}'.format(
+                    resp.status, content or '<empty>'))
 
     # The registry is authenticated iff we have an authentication challenge.
     if resp.status == httplib.OK:

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -214,16 +214,17 @@ class Transport(object):
         'content-type': 'application/json',
         'user-agent': docker_name.USER_AGENT,
     }
-    resp, unused_content = self._transport.request(
-        '{scheme}://{registry}/v2/'.format(scheme=Scheme(self._name.registry),
-                                           registry=self._name.registry),
+    resp, content = self._transport.request(
+        '{scheme}://{registry}/v2/'.format(
+            scheme=Scheme(self._name.registry), registry=self._name.registry),
         'GET',
         body=None,
         headers=headers)
 
     # We expect a www-authenticate challenge.
     _CheckState(resp.status in [httplib.OK, httplib.UNAUTHORIZED],
-                'Unexpected status: %d' % resp.status)
+                'Unexpected response pinging the registry: {}\nBody: {}'.format(
+                    resp.status, content or '<empty>'))
 
     # The registry is authenticated iff we have an authentication challenge.
     if resp.status == httplib.OK:

--- a/flatten.yaml
+++ b/flatten.yaml
@@ -2,9 +2,6 @@ steps:
 # Build the flatten PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    # TODO(user): Remove once this is released:
-    # https://github.com/GoogleCloudPlatform/cloud-builders/pull/29
-    '--output_base', '/workspace',
     'build', '//:flatten.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.

--- a/importer.yaml
+++ b/importer.yaml
@@ -2,9 +2,6 @@ steps:
 # Build the importer PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    # TODO(user): Remove once this is released:
-    # https://github.com/GoogleCloudPlatform/cloud-builders/pull/29
-    '--output_base', '/workspace',
     'build', '//:importer.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.

--- a/puller.yaml
+++ b/puller.yaml
@@ -2,9 +2,6 @@ steps:
 # Build the puller PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    # TODO(user): Remove once this is released:
-    # https://github.com/GoogleCloudPlatform/cloud-builders/pull/29
-    '--output_base', '/workspace',
     'build', '//:puller.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.

--- a/pusher.yaml
+++ b/pusher.yaml
@@ -2,9 +2,6 @@ steps:
 # Build the pusher PAR file
 - name: gcr.io/cloud-builders/bazel
   args: [
-    # TODO(user): Remove once this is released:
-    # https://github.com/GoogleCloudPlatform/cloud-builders/pull/29
-    '--output_base', '/workspace',
     'build', '//:pusher.par',
     # TODO(user): Remove once PAR compilation runs properly inside
     # the Bazel sandbox on cloudbuild.

--- a/tools/docker_puller_.py
+++ b/tools/docker_puller_.py
@@ -73,7 +73,7 @@ def main():
   logging_setup.Init(args=args)
 
   if not args.name or not args.tarball:
-    raise Exception('--name and --tarball are required arguments.')
+    logging.fatal('--name and --tarball are required arguments.')
 
   retry_factory = retry.Factory()
   retry_factory = retry_factory.WithSourceTransportCallable(httplib2.Http)
@@ -95,20 +95,28 @@ def main():
 
   # Resolve the appropriate credential to use based on the standard Docker
   # client logic.
-  creds = docker_creds.DefaultKeychain.Resolve(name)
+  try:
+    creds = docker_creds.DefaultKeychain.Resolve(name)
+  # pylint: disable=broad-except
+  except Exception as e:
+    logging.fatal('Error resolving credentials for %s: %s', name, e)
 
-  with tarfile.open(name=args.tarball, mode='w') as tar:
-    logging.info('Pulling v2.2 image from %r ...', name)
-    with v2_2_image.FromRegistry(name, creds, transport, accept) as v2_2_img:
-      if v2_2_img.exists():
-        save.tarball(_make_tag_if_digest(name), v2_2_img, tar)
-        return
+  try:
+    with tarfile.open(name=args.tarball, mode='w') as tar:
+      logging.info('Pulling v2.2 image from %r ...', name)
+      with v2_2_image.FromRegistry(name, creds, transport, accept) as v2_2_img:
+        if v2_2_img.exists():
+          save.tarball(_make_tag_if_digest(name), v2_2_img, tar)
+          return
 
-    logging.info('Pulling v2 image from %r ...', name)
-    with v2_image.FromRegistry(name, creds, transport) as v2_img:
-      with v2_compat.V22FromV2(v2_img) as v2_2_img:
-        save.tarball(_make_tag_if_digest(name), v2_2_img, tar)
-        return
+      logging.info('Pulling v2 image from %r ...', name)
+      with v2_image.FromRegistry(name, creds, transport) as v2_img:
+        with v2_compat.V22FromV2(v2_img) as v2_2_img:
+          save.tarball(_make_tag_if_digest(name), v2_2_img, tar)
+          return
+  # pylint: disable=broad-except
+  except Exception as e:
+    logging.fatal('Error pulling and saving image %s: %s', name, e)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add support for uncompressed image layers. Update fast_flatten to use it.
* Remove unnecessary `--output_base` bazel flag.
* Raise a more descriptive error when a /v2/ registry ping fails.
* Log errors on exceptions in the push/pull tools, rather than crash with a stack trace.

Fixes: google/containerregistry#56

Signed-off-by: Jake Sanders <jsand@google.com>