### PR TITLE
Reset Cmd when Entrypoint is specified

### DIFF
--- a/transform/v2_2/metadata_.py
+++ b/transform/v2_2/metadata_.py
@@ -160,6 +160,9 @@ def Override(data,
   # pytype: disable=attribute-error
   if options.entrypoint:
     output['config']['Entrypoint'] = options.entrypoint
+    # Cmd is cleared whenever Entrypoint changes.
+    # https://github.com/moby/moby/issues/19611#issuecomment-174244260
+    output['config'].pop('Cmd', None)
   if options.cmd:
     output['config']['Cmd'] = options.cmd
   if options.user:


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_docker/issues/379#issuecomment-381097502 for where this is useful.