### PR TITLE
Remove unused imports

### DIFF
--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -27,10 +27,6 @@ import logging
 import os
 import subprocess
 
-from containerregistry.client import docker_name
-import httplib2
-from oauth2client import client as oauth2client
-
 import six
 
 

--- a/client/v1/docker_http_.py
+++ b/client/v1/docker_http_.py
@@ -18,9 +18,7 @@ from __future__ import division
 
 from __future__ import print_function
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
-import httplib2
 
 
 class BadStatusException(Exception):

--- a/client/v1/docker_image_.py
+++ b/client/v1/docker_image_.py
@@ -30,12 +30,9 @@ import tarfile
 import tempfile
 import threading
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v1 import docker_creds as v1_creds
 from containerregistry.client.v1 import docker_http
-
-import httplib2
 
 import six
 from six.moves import range  # pylint: disable=redefined-builtin

--- a/client/v1/docker_session_.py
+++ b/client/v1/docker_session_.py
@@ -24,13 +24,9 @@ from __future__ import print_function
 
 import logging
 
-from containerregistry.client import docker_creds
-from containerregistry.client import docker_name
 from containerregistry.client.v1 import docker_creds as v1_creds
 from containerregistry.client.v1 import docker_http
-from containerregistry.client.v1 import docker_image
 
-import httplib2
 import six.moves.http_client
 
 

--- a/client/v2/docker_http_.py
+++ b/client/v2/docker_http_.py
@@ -26,8 +26,6 @@ from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2 import docker_creds as v2_creds
 
-import httplib2
-
 import six.moves.http_client
 import six.moves.urllib.parse
 

--- a/client/v2/docker_image_.py
+++ b/client/v2/docker_image_.py
@@ -25,12 +25,10 @@ import json
 import os
 import tarfile
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2 import docker_digest
 from containerregistry.client.v2 import docker_http
 
-import httplib2
 import six
 import six.moves.http_client
 

--- a/client/v2/docker_session_.py
+++ b/client/v2/docker_session_.py
@@ -21,12 +21,8 @@ from __future__ import print_function
 import logging
 import concurrent.futures
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2 import docker_http
-from containerregistry.client.v2 import docker_image
-
-import httplib2
 
 import six.moves.http_client
 import six.moves.urllib.parse

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -25,7 +25,6 @@ import threading
 from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2_2 import docker_creds as v2_2_creds
-import httplib2
 import six.moves.http_client
 import six.moves.urllib.parse
 

--- a/client/v2_2/docker_image_.py
+++ b/client/v2_2/docker_image_.py
@@ -26,11 +26,9 @@ import os
 import tarfile
 import threading
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2_2 import docker_digest
 from containerregistry.client.v2_2 import docker_http
-import httplib2
 import six
 from six.moves import zip  # pylint: disable=redefined-builtin
 import six.moves.http_client

--- a/client/v2_2/docker_image_list_.py
+++ b/client/v2_2/docker_image_list_.py
@@ -21,13 +21,11 @@ from __future__ import print_function
 import abc
 import json
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2_2 import docker_digest
 from containerregistry.client.v2_2 import docker_http
 from containerregistry.client.v2_2 import docker_image as v2_2_image
 
-import httplib2
 import six
 import six.moves.http_client
 

--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -21,12 +21,9 @@ from __future__ import print_function
 import logging
 import concurrent.futures
 
-from containerregistry.client import docker_creds
 from containerregistry.client import docker_name
 from containerregistry.client.v2_2 import docker_http
-from containerregistry.client.v2_2 import docker_image
 from containerregistry.client.v2_2 import docker_image_list as image_list
-import httplib2
 
 import six.moves.http_client
 import six.moves.urllib.parse


### PR DESCRIPTION
The `import httplib2` specifically will give issues when python 3 is used.