### PR TITLE
Add manifest to image digester.

### DIFF
--- a/tools/image_digest_.py
+++ b/tools/image_digest_.py
@@ -49,6 +49,12 @@ parser.add_argument(
     help='The path to the file storing the image config.')
 
 parser.add_argument(
+    '--manifest',
+    action='store',
+    required=False,
+    help='The path to the file storing the image manifest.')
+
+parser.add_argument(
     '--digest',
     action='append',
     help='The list of layer digest filenames in order.')
@@ -77,6 +83,7 @@ def main():
   # If config is specified, use that.  Otherwise, fallback on reading
   # the config from the tarball.
   config = args.config
+  manifest = args.manifest
   if args.config:
     logging.info('Reading config from %r', args.config)
     with open(args.config, 'r') as reader:
@@ -86,6 +93,10 @@ def main():
     with v2_2_image.FromTarball(args.tarball) as base:
       config = base.config_file()
 
+  if args.manifest:
+    with open(args.manifest, 'r') as reader:
+      manifest = reader.read()
+
   if len(args.digest or []) != len(args.layer or []):
     logging.fatal('--digest and --layer must have matching lengths.')
     sys.exit(1)
@@ -94,7 +105,8 @@ def main():
   with v2_2_image.FromDisk(
       config,
       list(zip(args.digest or [], args.layer or [])),
-      legacy_base=args.tarball) as v2_2_img:
+      legacy_base=args.tarball,
+      foreign_layers_manifest=manifest) as v2_2_img:
 
     try:
       if args.oci:

--- a/tools/image_digester_.py
+++ b/tools/image_digester_.py
@@ -49,6 +49,12 @@ parser.add_argument(
     help='The path to the file storing the image config.')
 
 parser.add_argument(
+    '--manifest',
+    action='store',
+    required=False,
+    help='The path to the file storing the image manifest.')
+
+parser.add_argument(
     '--digest',
     action='append',
     help='The list of layer digest filenames in order.')
@@ -77,6 +83,7 @@ def main():
   # If config is specified, use that.  Otherwise, fallback on reading
   # the config from the tarball.
   config = args.config
+  manifest = args.manifest
   if args.config:
     logging.info('Reading config from %r', args.config)
     with open(args.config, 'r') as reader:
@@ -86,6 +93,10 @@ def main():
     with v2_2_image.FromTarball(args.tarball) as base:
       config = base.config_file()
 
+  if args.manifest:
+    with open(args.manifest, 'r') as reader:
+      manifest = reader.read()
+
   if len(args.digest or []) != len(args.layer or []):
     logging.fatal('--digest and --layer must have matching lengths.')
     sys.exit(1)
@@ -94,7 +105,8 @@ def main():
   with v2_2_image.FromDisk(
       config,
       list(zip(args.digest or [], args.layer or [])),
-      legacy_base=args.tarball) as v2_2_img:
+      legacy_base=args.tarball,
+      foreign_layers_manifest=manifest) as v2_2_img:
 
     try:
       if args.oci:


### PR DESCRIPTION
The --manifest was added to fast_pusher_.py in 2acf47112aeadb8622aace2918310f93a668c8b3, but forgotten in image_digest_.py and image_digester_.py.

I'm not sure why image_digest_.py exists in the first place, it isn't used in any public rules. I'd also be happy to just drop the file.