### PR TITLE
Save manifest json and digest, and allow specifying platform when pulling images

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ bazel run @containerregistry//:puller.par -- --help
 ```
 
 ```
-usage: puller.par [-h] [--name NAME] [--directory DIRECTORY]
-                  [--platform PLATFORM] [--stderrthreshold STDERRTHRESHOLD]
+usage: puller.par [-h] --name NAME --directory DIRECTORY [--platform PLATFORM]
+                  [--stderrthreshold STDERRTHRESHOLD]
 
 Pull images from a Docker Registry, faaaaast.
 
@@ -44,8 +44,8 @@ optional arguments:
                         Supports fully-qualified tag or digest references.
   --directory DIRECTORY
                         Where to save the image's files.
-  --platform PLATFORM   Which platform image to pull for multi-platform manifest
-                        lists. Formatted as os/arch.
+  --platform PLATFORM   Which platform image to pull for multi-platform
+                        manifest lists. Formatted as os/arch.
   --stderrthreshold STDERRTHRESHOLD
                         Write log events at or above this level to stderr.
 ```
@@ -57,8 +57,8 @@ $ bazel run @containerregistry//:pusher.par -- --help
 ```
 
 ```
-usage: pusher.par [-h] [--name NAME] [--tarball TARBALL] [--config CONFIG]
-                  [--digest DIGEST] [--layer LAYER]
+usage: pusher.par [-h] --name NAME [--tarball TARBALL] [--config CONFIG]
+                  [--manifest MANIFEST] [--digest DIGEST] [--layer LAYER]
                   [--stamp-info-file STAMP_INFO_FILE] [--oci]
                   [--stderrthreshold STDERRTHRESHOLD]
 
@@ -69,6 +69,7 @@ optional arguments:
   --name NAME           The name of the docker image to push.
   --tarball TARBALL     An optional legacy base image tarball.
   --config CONFIG       The path to the file storing the image config.
+  --manifest MANIFEST   The path to the file storing the image manifest.
   --digest DIGEST       The list of layer digest filenames in order.
   --layer LAYER         The list of layer filenames in order.
   --stamp-info-file STAMP_INFO_FILE
@@ -86,9 +87,8 @@ $ bazel run @containerregistry//:importer.par -- --help
 ```
 
 ```
-usage: importer.par [-h] [--tarball TARBALL] [--format {tar,tar.gz}]
-                    [--directory DIRECTORY]
-                    [--stderrthreshold STDERRTHRESHOLD]
+usage: importer.par [-h] --tarball TARBALL [--format {tar,tar.gz}] --directory
+                    DIRECTORY [--stderrthreshold STDERRTHRESHOLD]
 
 Import images from a tarball into our faaaaaast format.
 
@@ -143,9 +143,8 @@ $ bazel run @containerregistry//:appender.par -- --help
 ```
 
 ```
-usage: appender.par [-h] [--src-image SRC_IMAGE] [--tarball TARBALL]
-                    [--dst-image DST_IMAGE]
-                    [--stderrthreshold STDERRTHRESHOLD]
+usage: appender.par [-h] --src-image SRC_IMAGE --tarball TARBALL --dst-image
+                    DST_IMAGE [--stderrthreshold STDERRTHRESHOLD]
 
 Append tarballs to an image in a Docker Registry.
 
@@ -158,7 +157,6 @@ optional arguments:
                         The name of the new image.
   --stderrthreshold STDERRTHRESHOLD
                         Write log events at or above this level to stderr.
-
 ```
 
 ## digester.par
@@ -169,7 +167,8 @@ $ bazel run @containerregistry//:digester.par -- --help
 
 ```
 usage: digester.par [-h] [--tarball TARBALL] --output-digest OUTPUT_DIGEST
-                    [--config CONFIG] [--digest DIGEST] [--layer LAYER] [--oci]
+                    [--config CONFIG] [--manifest MANIFEST] [--digest DIGEST]
+                    [--layer LAYER] [--oci]
                     [--stderrthreshold STDERRTHRESHOLD]
 
 Calculate digest for a container image.
@@ -180,10 +179,10 @@ optional arguments:
   --output-digest OUTPUT_DIGEST
                         Filename to store digest in.
   --config CONFIG       The path to the file storing the image config.
+  --manifest MANIFEST   The path to the file storing the image manifest.
   --digest DIGEST       The list of layer digest filenames in order.
   --layer LAYER         The list of layer filenames in order.
   --oci                 Image has an OCI Manifest.
   --stderrthreshold STDERRTHRESHOLD
                         Write log events at or above this level to stderr.
-
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ bazel run @containerregistry//:puller.par -- --help
 
 ```
 usage: puller.par [-h] [--name NAME] [--directory DIRECTORY]
-                  [--stderrthreshold STDERRTHRESHOLD]
+                  [--platform PLATFORM] [--stderrthreshold STDERRTHRESHOLD]
 
 Pull images from a Docker Registry, faaaaast.
 
@@ -44,6 +44,8 @@ optional arguments:
                         Supports fully-qualified tag or digest references.
   --directory DIRECTORY
                         Where to save the image's files.
+  --platform PLATFORM   Which platform image to pull for multi-platform manifest
+                        lists. Formatted as os/arch.
   --stderrthreshold STDERRTHRESHOLD
                         Write log events at or above this level to stderr.
 ```

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -146,12 +146,14 @@ def fast(image, directory,
 
   After calling this, the following filesystem will exist:
     directory/
-      config.json  <-- only *.json, the image's config
-      001.tar.gz   <-- the first layer's .tar.gz filesystem delta
-      001.sha256   <-- the sha256 of 1.tar.gz with a "sha256:" prefix.
+      config.json   <-- only *.json, the image's config
+      digest        <-- sha256 digest of the image's manifest
+      manifest.json <-- the image's manifest
+      001.tar.gz    <-- the first layer's .tar.gz filesystem delta
+      001.sha256    <-- the sha256 of 1.tar.gz with a "sha256:" prefix.
       ...
-      N.tar.gz     <-- the Nth layer's .tar.gz filesystem delta
-      N.sha256     <-- the sha256 of N.tar.gz with a "sha256:" prefix.
+      N.tar.gz      <-- the Nth layer's .tar.gz filesystem delta
+      N.sha256      <-- the sha256 of N.tar.gz with a "sha256:" prefix.
 
   We pad layer indices to only 3 digits because of a known ceiling on the number
   of filesystem layers Docker supports.
@@ -179,6 +181,12 @@ def fast(image, directory,
                         lambda unused: image.config_file().encode('utf8'),
                         'unused')
     future_to_params[f] = config_file
+
+    executor.submit(write_file, os.path.join(directory, 'digest'),
+                    lambda unused: image.digest(), 'unused')
+    executor.submit(write_file, os.path.join(directory, 'manifest.json'),
+                    lambda unused: image.manifest().encode('utf8'),
+                    'unused')
 
     idx = 0
     layers = []
@@ -214,12 +222,14 @@ def uncompressed(image,
 
   After calling this, the following filesystem will exist:
     directory/
-      config.json  <-- only *.json, the image's config
-      001.tar      <-- the first layer's .tar filesystem delta
-      001.sha256   <-- the sha256 of 001.tar with a "sha256:" prefix.
+      config.json   <-- only *.json, the image's config
+      digest        <-- sha256 digest of the image's manifest
+      manifest.json <-- the image's manifest
+      001.tar       <-- the first layer's .tar filesystem delta
+      001.sha256    <-- the sha256 of 001.tar with a "sha256:" prefix.
       ...
-      NNN.tar      <-- the NNNth layer's .tar filesystem delta
-      NNN.sha256   <-- the sha256 of NNN.tar with a "sha256:" prefix.
+      NNN.tar       <-- the NNNth layer's .tar filesystem delta
+      NNN.sha256    <-- the sha256 of NNN.tar with a "sha256:" prefix.
 
   We pad layer indices to only 3 digits because of a known ceiling on the number
   of filesystem layers Docker supports.
@@ -247,6 +257,12 @@ def uncompressed(image,
                         lambda unused: image.config_file().encode('utf8'),
                         'unused')
     future_to_params[f] = config_file
+
+    executor.submit(write_file, os.path.join(directory, 'digest'),
+                    lambda unused: image.digest(), 'unused')
+    executor.submit(write_file, os.path.join(directory, 'manifest.json'),
+                    lambda unused: image.manifest().encode('utf8'),
+                    'unused')
 
     idx = 0
     layers = []

--- a/tools/docker_appender_.py
+++ b/tools/docker_appender_.py
@@ -37,12 +37,15 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     '--src-image',
     action='store',
-    help=('The name of the docker image to append to.'))
+    help='The name of the docker image to append to.',
+    required=True)
 
-parser.add_argument('--tarball', action='store', help='The tarball to append.')
+parser.add_argument('--tarball', action='store', help='The tarball to append.',
+                    required=True)
 
 parser.add_argument(
-    '--dst-image', action='store', help='The name of the new image.')
+    '--dst-image', action='store', help='The name of the new image.',
+    required=True)
 
 _THREADS = 8
 
@@ -51,10 +54,6 @@ def main():
   logging_setup.DefineCommandLineArgs(parser)
   args = parser.parse_args()
   logging_setup.Init(args=args)
-
-  if not args.src_image or not args.tarball or not args.dst_image:
-    raise Exception('--src-image, --dst-image and --tarball are required '
-                    'arguments.')
 
   transport = transport_pool.Http(httplib2.Http, size=_THREADS)
 

--- a/tools/docker_puller_.py
+++ b/tools/docker_puller_.py
@@ -48,11 +48,12 @@ parser.add_argument(
 parser.add_argument(
     '--tarball', action='store', help='Where to save the image tarball.')
 
+parser.add_argument(
+    '--platform', action='store', default='linux/amd64',
+    help=('Which platform image to pull for multi-platform manifest lists. '
+          'Formatted as os/arch.'))
+
 _DEFAULT_TAG = 'i-was-a-digest'
-
-_PROCESSOR_ARCHITECTURE = 'amd64'
-
-_OPERATING_SYSTEM = 'linux'
 
 
 # Today save.tarball expects a tag, which is emitted into one or more files
@@ -82,6 +83,11 @@ def main():
   if not args.name or not args.tarball:
     logging.fatal('--name and --tarball are required arguments.')
     sys.exit(1)
+  if '/' not in args.platform:
+    logging.fatal('--platform must be specified in os/arch format.')
+    sys.exit(1)
+
+  os, arch = args.platform.split('/', 1)
 
   retry_factory = retry.Factory()
   retry_factory = retry_factory.WithSourceTransportCallable(httplib2.Http)
@@ -116,8 +122,8 @@ def main():
       with image_list.FromRegistry(name, creds, transport) as img_list:
         if img_list.exists():
           platform = image_list.Platform({
-              'architecture': _PROCESSOR_ARCHITECTURE,
-              'os': _OPERATING_SYSTEM,
+              'architecture': arch,
+              'os': os,
           })
           # pytype: disable=wrong-arg-types
           with img_list.resolve(platform) as default_child:

--- a/tools/docker_puller_.py
+++ b/tools/docker_puller_.py
@@ -43,10 +43,12 @@ parser.add_argument(
     '--name',
     action='store',
     help=('The name of the docker image to pull and save. '
-          'Supports fully-qualified tag or digest references.'))
+          'Supports fully-qualified tag or digest references.'),
+    required=True)
 
 parser.add_argument(
-    '--tarball', action='store', help='Where to save the image tarball.')
+    '--tarball', action='store', help='Where to save the image tarball.',
+    required=True)
 
 parser.add_argument(
     '--platform', action='store', default='linux/amd64',
@@ -80,9 +82,6 @@ def main():
   args = parser.parse_args()
   logging_setup.Init(args=args)
 
-  if not args.name or not args.tarball:
-    logging.fatal('--name and --tarball are required arguments.')
-    sys.exit(1)
   if '/' not in args.platform:
     logging.fatal('--platform must be specified in os/arch format.')
     sys.exit(1)

--- a/tools/docker_pusher_.py
+++ b/tools/docker_pusher_.py
@@ -38,10 +38,12 @@ parser = argparse.ArgumentParser(
     description='Push images to a Docker Registry.')
 
 parser.add_argument(
-    '--name', action='store', help=('The name of the docker image to push.'))
+    '--name', action='store', help='The name of the docker image to push.',
+    required=True)
 
 parser.add_argument(
-    '--tarball', action='store', help='Where to load the image tarball.')
+    '--tarball', action='store', help='Where to load the image tarball.',
+    required=True)
 
 parser.add_argument(
     '--stamp-info-file',
@@ -78,10 +80,6 @@ def main():
   logging_setup.DefineCommandLineArgs(parser)
   args = parser.parse_args()
   logging_setup.Init(args=args)
-
-  if not args.name or not args.tarball:
-    logging.fatal('--name and --tarball are required arguments.')
-    sys.exit(1)
 
   retry_factory = retry.Factory()
   retry_factory = retry_factory.WithSourceTransportCallable(httplib2.Http)

--- a/tools/fast_importer_.py
+++ b/tools/fast_importer_.py
@@ -33,7 +33,8 @@ parser.add_argument(
     '--tarball',
     action='store',
     help=('The tarball containing the docker image to rewrite '
-          'into our fast on-disk format.'))
+          'into our fast on-disk format.'),
+    required=True)
 
 parser.add_argument(
     '--format',
@@ -43,7 +44,8 @@ parser.add_argument(
     help='The form in which to save layers.')
 
 parser.add_argument(
-    '--directory', action='store', help='Where to save the image\'s files.')
+    '--directory', action='store', help='Where to save the image\'s files.',
+    required=True)
 
 _THREADS = 32
 
@@ -52,9 +54,6 @@ def main():
   logging_setup.DefineCommandLineArgs(parser)
   args = parser.parse_args()
   logging_setup.Init(args=args)
-
-  if not args.tarball or not args.directory:
-    raise Exception('--tarball and --directory are required arguments.')
 
   method = save.uncompressed
   if args.format == 'tar.gz':

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -45,10 +45,12 @@ parser.add_argument(
     '--name',
     action='store',
     help=('The name of the docker image to pull and save. '
-          'Supports fully-qualified tag or digest references.'))
+          'Supports fully-qualified tag or digest references.'),
+    required=True)
 
 parser.add_argument(
-    '--directory', action='store', help='Where to save the image\'s files.')
+    '--directory', action='store', help='Where to save the image\'s files.',
+    required=True)
 
 parser.add_argument(
     '--platform', action='store', default='linux/amd64',
@@ -63,9 +65,6 @@ def main():
   args = parser.parse_args()
   logging_setup.Init(args=args)
 
-  if not args.name or not args.directory:
-    logging.fatal('--name and --directory are required arguments.')
-    sys.exit(1)
   if '/' not in args.platform:
     logging.fatal('--platform must be specified in os/arch format.')
     sys.exit(1)

--- a/tools/fast_pusher_.py
+++ b/tools/fast_pusher_.py
@@ -44,7 +44,8 @@ parser = argparse.ArgumentParser(
     description='Push images to a Docker Registry, faaaaaast.')
 
 parser.add_argument(
-    '--name', action='store', help=('The name of the docker image to push.'))
+    '--name', action='store', help='The name of the docker image to push.',
+    required=True)
 
 # The name of this flag was chosen for compatibility with docker_pusher.py
 parser.add_argument(
@@ -108,10 +109,6 @@ def main():
   logging_setup.DefineCommandLineArgs(parser)
   args = parser.parse_args()
   logging_setup.Init(args=args)
-
-  if not args.name:
-    logging.fatal('--name is a required arguments.')
-    sys.exit(1)
 
   # This library can support push-by-digest, but the likelihood of a user
   # correctly providing us with the digest without using this library


### PR DESCRIPTION
These are a few enhancements needed by https://github.com/bazelbuild/rules_docker/issues/543.

First, I'm saving the `manifest.json` and docker digest of this manifest out to files. This lets us figure out the resolved digest from a tag, so we can reproduce the pull later.

Second, I've added a flag to control which platform image to pull from a manifest list. This way we can let builds be explicit, rather than always pulling `linux/amd64` (or worse, whatever is their host platform).

I've tested this manually by pulling several images, but I can't seem to get the tests to run under `bazel test` - it wants to write out to my `$HOME/.config/gcloud/credentials.db`, which seems broken.