### PR TITLE
decode contents before parsing as json

### DIFF
--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -308,6 +308,9 @@ class Transport(object):
       raise TokenRefreshException('Bad status during token exchange: %d\n%s' %
                                   (resp.status, content))
 
+    if not isinstance(content, str):
+        content = content.decode('utf-8')
+
     wrapper_object = json.loads(content)
     token = wrapper_object.get('token') or wrapper_object.get('access_token')
     _CheckState(token is not None, 'Malformed JSON response: %s' % content)


### PR DESCRIPTION
Fixes a runtime error when running "docker pull" using the exposed API from a vanilla Python3.5 / Python3.6 (tested with Debian9)