### PR TITLE
Add docker cache directory

### DIFF
--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -32,7 +32,6 @@ from containerregistry.client.v2_2 import docker_digest
 from containerregistry.client.v2_2 import docker_http
 from containerregistry.client.v2_2 import docker_image as v2_2_image
 from containerregistry.client.v2_2 import v2_compat
-from containerregistry.client.v2_2 import docker_digest
 
 import six
 
@@ -181,6 +180,9 @@ def fast(image, directory,
     link(cached_layer, name)
 
   def link(source, link):
+    # unlink first to remove "old" layers if needed, e.g., image A latest has layers 1, 2 and 3
+    # after a while it has layers 1, 2 and 3'. Since in both cases the layers are named 001, 002 and 003
+    # Unlinking promises the correct layers are linked in the image directory
     if os.path.exists(link):
       os.unlink(link)
     os.link(source, link)

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -176,9 +176,9 @@ def fast(image, directory,
       f.write(accessor(arg))
 
   def write_file_and_store(name, accessor,
-                           arg, cached_name):
+                           arg, cached_layer):
     write_file(name, accessor, arg)
-    copy(name, cached_name)
+    copy(name, cached_layer)
 
   with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
     future_to_params = {}
@@ -212,8 +212,7 @@ def fast(image, directory,
 
       if cache_directory:
         # Search for a local cached copy
-        layer_cache_directory = os.path.join(cache_directory, digest)
-        cached_layer = os.path.join(layer_cache_directory, "000.tar.gz")
+        cached_layer = os.path.join(cache_directory, digest)
         if os.path.exists(cached_layer):
           # TODO - validate sha256 of the cached copy
           f = executor.submit(

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -32,6 +32,7 @@ from containerregistry.client.v2_2 import docker_digest
 from containerregistry.client.v2_2 import docker_http
 from containerregistry.client.v2_2 import docker_image as v2_2_image
 from containerregistry.client.v2_2 import v2_compat
+from containerregistry.client.v2_2 import docker_digest
 
 import six
 
@@ -184,6 +185,11 @@ def fast(image, directory,
       os.unlink(link)
     os.link(source, link)
 
+  def valid(cached_layer, digest):
+    with io.open(cached_layer, u'rb') as f:
+      current_digest = docker_digest.SHA256(f.read(), '')
+    return current_digest == digest
+
   with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
     future_to_params = {}
     config_file = os.path.join(directory, 'config.json')
@@ -217,8 +223,7 @@ def fast(image, directory,
       if cache_directory:
         # Search for a local cached copy
         cached_layer = os.path.join(cache_directory, digest)
-        if os.path.exists(cached_layer):
-          # TODO - validate sha256 of the cached copy
+        if os.path.exists(cached_layer) and valid(cached_layer, digest):
           f = executor.submit(
             link,
             cached_layer,

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -22,6 +22,7 @@ import io
 import json
 import os
 import tarfile
+from shutil import copy
 
 import concurrent.futures
 from containerregistry.client import docker_name
@@ -141,7 +142,7 @@ def tarball(name, image,
 
 
 def fast(image, directory,
-         threads = 1):
+         threads = 1, cache_directory = None):
   """Produce a FromDisk compatible file layout under the provided directory.
 
   After calling this, the following filesystem will exist:
@@ -174,6 +175,11 @@ def fast(image, directory,
     with io.open(name, u'wb') as f:
       f.write(accessor(arg))
 
+  def write_file_and_store(name, accessor,
+                           arg, cached_name):
+    write_file(name, accessor, arg)
+    copy(name, cached_name)
+
   with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
     future_to_params = {}
     config_file = os.path.join(directory, 'config.json')
@@ -192,18 +198,35 @@ def fast(image, directory,
     layers = []
     for blob in reversed(image.fs_layers()):
       # Create a local copy
+      layer_name = os.path.join(directory, '%03d.tar.gz' % idx)
       digest_name = os.path.join(directory, '%03d.sha256' % idx)
+      digest = blob[7:].encode('utf8')
+
       f = executor.submit(
-          write_file,
-          digest_name,
-          # Strip the sha256: prefix
-          lambda blob: blob[7:].encode('utf8'),
-          blob)
+        write_file,
+        digest_name,
+        lambda unused: digest,
+        'unused')
+
       future_to_params[f] = digest_name
 
-      layer_name = os.path.join(directory, '%03d.tar.gz' % idx)
-      f = executor.submit(write_file, layer_name, image.blob, blob)
-      future_to_params[f] = layer_name
+      if cache_directory:
+        # Search for a local cached copy
+        layer_cache_directory = os.path.join(cache_directory, digest)
+        cached_layer = os.path.join(layer_cache_directory, "000.tar.gz")
+        if os.path.exists(cached_layer):
+          # TODO - validate sha256 of the cached copy
+          f = executor.submit(
+            copy,
+            cached_layer,
+            layer_name)
+          future_to_params[f] = layer_name
+        else:
+          f = executor.submit(write_file_and_store, layer_name, image.blob, blob, cached_layer)
+          future_to_params[f] = layer_name
+      else:
+        f = executor.submit(write_file, layer_name, image.blob, blob)
+        future_to_params[f] = layer_name
 
       layers.append((digest_name, layer_name))
       idx += 1

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -22,7 +22,6 @@ import io
 import json
 import os
 import tarfile
-from shutil import copy
 
 import concurrent.futures
 from containerregistry.client import docker_name
@@ -177,8 +176,13 @@ def fast(image, directory,
 
   def write_file_and_store(name, accessor,
                            arg, cached_layer):
-    write_file(name, accessor, arg)
-    copy(name, cached_layer)
+    write_file(cached_layer, accessor, arg)
+    link(cached_layer, name)
+
+  def link(source, link):
+    if os.path.exists(link):
+      os.unlink(link)
+    os.link(source, link)
 
   with concurrent.futures.ThreadPoolExecutor(max_workers=threads) as executor:
     future_to_params = {}
@@ -216,7 +220,7 @@ def fast(image, directory,
         if os.path.exists(cached_layer):
           # TODO - validate sha256 of the cached copy
           f = executor.submit(
-            copy,
+            link,
             cached_layer,
             layer_name)
           future_to_params[f] = layer_name

--- a/puller_test.sh
+++ b/puller_test.sh
@@ -19,6 +19,8 @@
 # Trick to chase the symlink before the docker build.
 cp -f puller.par puller2.par
 
+timing=-1
+
 # Test pulling an image by just invoking the puller
 function test_puller() {
   local image=$1
@@ -81,6 +83,56 @@ function test_image() {
   test_base "${image}" python2.7 gcr.io/cloud-builders/bazel
 }
 
+function test_puller_with_cache() {
+  local image=$1
+
+  # Test it in our current environment.
+  puller.par --name="${image}" --directory=/tmp/ --cache=/tmp/containerregistery_docker_cache_dir
+}
+
+function test_image_with_cache() {
+  local image=$1
+
+  test_image_with_timing "${image}"
+  local first_pull_timing=$timing
+  echo "TIMING: ${image} - First pull took ${first_pull_timing} seconds"
+
+  test_image_with_timing "${image}"
+  local second_pull_timing=$timing
+  echo "TIMING: ${image} - Second pull took ${second_pull_timing} seconds"
+
+  # TODO - is there a better way to test that the cache was used beside asserting the first_pull > second_pull???
+}
+
+function test_image_with_timing() {
+  local image=$1
+
+  echo "TESTING: ${image}"
+
+  local pull_start=$(date +%s)
+  test_puller_with_cache "${image}"
+
+  local pull_end=$(date +%s)
+  timing=$(($pull_end-$pull_start))
+
+  test_base "${image}" python2.7 python:2.7
+  test_base "${image}" python2.7 gcr.io/cloud-builders/bazel
+}
+
+function clear_cache_directory() {
+  rm -fr /tmp/containerregistery_docker_cache_dir
+}
+
+function create_cache_directory() {
+  mkdir -p /tmp/containerregistery_docker_cache_dir
+}
+
+clear_cache_directory
+create_cache_directory
+
+# Test pulling with cache
+test_image_with_cache gcr.io/google-appengine/python:latest
+
 # Test pulling a trivial image.
 test_image gcr.io/google-containers/pause:2.0
 
@@ -125,3 +177,5 @@ test_puller_multiplatform index.docker.io/library/busybox:1.29.3 \
 # TODO: add multiplatform test cases on --os-features and --features
 
 # TODO(user): Add an authenticated pull test.
+
+clear_cache_directory

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -61,6 +61,9 @@ parser.add_argument(
     help='The path to the directory where the client configuration files are '
     'located. Overiddes the value from DOCKER_CONFIG')
 
+parser.add_argument(
+  '--cache', action='store', help='Image\'s files cache directory.')
+
 _THREADS = 8
 
 
@@ -115,13 +118,13 @@ def main():
     logging.info('Pulling v2.2 image from %r ...', name)
     with v2_2_image.FromRegistry(name, creds, transport, accept) as v2_2_img:
       if v2_2_img.exists():
-        save.fast(v2_2_img, args.directory, threads=_THREADS)
+        save.fast(v2_2_img, args.directory, args.cache, threads=_THREADS)
         return
 
     logging.info('Pulling v2 image from %r ...', name)
     with v2_image.FromRegistry(name, creds, transport) as v2_img:
       with v2_compat.V22FromV2(v2_img) as v2_2_img:
-        save.fast(v2_2_img, args.directory, threads=_THREADS)
+        save.fast(v2_2_img, args.directory, args.cache, threads=_THREADS)
         return
   # pylint: disable=broad-except
   except Exception as e:

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -111,20 +111,20 @@ def main():
         platform = platform_args.FromArgs(args)
         # pytype: disable=wrong-arg-types
         with img_list.resolve(platform) as default_child:
-          save.fast(default_child, args.directory, threads=_THREADS)
+          save.fast(default_child, args.directory, threads=_THREADS, cache_directory=args.cache)
           return
         # pytype: enable=wrong-arg-types
 
     logging.info('Pulling v2.2 image from %r ...', name)
     with v2_2_image.FromRegistry(name, creds, transport, accept) as v2_2_img:
       if v2_2_img.exists():
-        save.fast(v2_2_img, args.directory, args.cache, threads=_THREADS)
+        save.fast(v2_2_img, args.directory, threads=_THREADS, cache_directory=args.cache)
         return
 
     logging.info('Pulling v2 image from %r ...', name)
     with v2_image.FromRegistry(name, creds, transport) as v2_img:
       with v2_compat.V22FromV2(v2_img) as v2_2_img:
-        save.fast(v2_2_img, args.directory, args.cache, threads=_THREADS)
+        save.fast(v2_2_img, args.directory, threads=_THREADS, cache_directory=args.cache)
         return
   # pylint: disable=broad-except
   except Exception as e:


### PR DESCRIPTION
This is how we see the solution for #120 

This adds a new param for the `puller` called `cache`. The cache is a directory that contains files, each file represents a downloaded layer. The name of the file is the sha256 digest of the layer, e.g.,:
```
ls -lrth /tmp/containerregistery_docker_cache_dir/

total 657024
-rw-r--r--  1 shacharan  wheel   1.1K Oct 31 17:14 aa4fba57ac1db051f077081c07f18e71ce71a0e6072f103bc96f9b1c3d13d88a
-rw-r--r--  1 shacharan  wheel    49B Oct 31 17:14 3c2cba919283a210665e480bcbf943eaaf4ed87a83f02e81bb286b8bdead0e75
-rw-r--r--  1 shacharan  wheel   548B Oct 31 17:14 3a8c4e273091c5d2d0e5d33cca6212908cd1c6be5b5f067891134e6c5ebc8337
-rw-r--r--  1 shacharan  wheel   304B Oct 31 17:14 9e64678d1ff1968d3a085e15e89ef2c4ef8fc3ec43ea3366360b60b4ece5a35b
-rw-r--r--  1 shacharan  wheel   1.2K Oct 31 17:14 e322f069a73f3df1063ef9426dbcbd8893da363c83b21e19f051d2d9dc5610d1
-rw-r--r--  1 shacharan  wheel   133B Oct 31 17:14 869a054d43cae87ab94bc5281093bf6607bb35b735ff4fb50e3240b983e39329
-rw-r--r--  1 shacharan  wheel   103B Oct 31 17:14 c3009d16228c1e02aa68a4cdefcaa1c89d53f0c3d4eab7a1b83135142f2deb65
-rw-r--r--  1 shacharan  wheel   9.3M Oct 31 17:14 a7e8e7eaedca8668dd45fbf03ad36e9f3bfe59e1b68513f6c6b59f714cd886f4
-rw-r--r--  1 shacharan  wheel    19M Oct 31 17:14 b69ccad74a2ee701b20f29f72720cf6a77ab308da8992d1655320466d3623a94
-rw-r--r--  1 shacharan  wheel    41M Oct 31 17:14 e5c573070776a0eb8cd15741f83354eb579ef0d73eba45cafa7e8191c3230f8f
-rw-r--r--  1 shacharan  wheel    78M Oct 31 17:14 7c433672d0c12d1914a2eb8b64ea02124179c85e8a9c8d6ea251b14c442ab8ea
-rw-r--r--  1 shacharan  wheel   173M Oct 31 17:14 a89aa118056a99a455c1efb055838394ef8b89e940ac758525cfd48e90759d4a
```

There a few issues that still needs to be solved:
1. ~~Is it require to validate the cached layer sha256 (the same way it is done in `docker_image#blob`)?~~
2. What is the correct way to test this feature? I added a test that pulls and test the same image twice

Other issues are more style oriented, e.g., create a cache object that will wrap the `save` object

cc: @ittaiz 