### PR TITLE
bump httplib2 version

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -15,9 +15,9 @@
 def repositories():
     native.new_http_archive(
         name = "httplib2",
-        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.10.3",
-        sha256 = "d1bee28a68cc665c451c83d315e3afdbeb5391f08971dcc91e060d5ba16986f1",
-        strip_prefix = "httplib2-0.10.3/python2/httplib2/",
+        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
+        sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
+        strip_prefix = "httplib2-0.11.3/python2/httplib2/",
         type = "tar.gz",
         build_file_content = """
 py_library(


### PR DESCRIPTION
The current version of httplib2 has CA certs that we need.  This needs to stay up to date.