### PR TITLE
Use a custom docker client config directory for pull & push if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ bazel run @containerregistry//:puller.par -- --help
 
 ```
 usage: puller.par [-h] --name NAME --directory DIRECTORY [--platform PLATFORM]
+                  [--client-config-dir CLIENT_CONFIG_DIR]
                   [--stderrthreshold STDERRTHRESHOLD]
 
 Pull images from a Docker Registry, faaaaast.
@@ -59,7 +60,8 @@ $ bazel run @containerregistry//:pusher.par -- --help
 ```
 usage: pusher.par [-h] --name NAME [--tarball TARBALL] [--config CONFIG]
                   [--manifest MANIFEST] [--digest DIGEST] [--layer LAYER]
-                  [--stamp-info-file STAMP_INFO_FILE] [--oci]
+                  [--stamp-info-file STAMP_INFO_FILE]
+                  [--client-config-dir CLIENT_CONFIG_DIR] [--oci]
                   [--stderrthreshold STDERRTHRESHOLD]
 
 Push images to a Docker Registry, faaaaaast.

--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -230,12 +230,30 @@ def _GetConfigDirectory():
 
 class _DefaultKeychain(Keychain):
   """This implements the default docker credential resolution."""
+  def __init__(self):
+    # Store a custom directory to get the Docker configuration JSON from
+    self._config_dir = None
+    # Name of the docker configuration JSON file to look for in the
+    # configuration directory
+    self._config_file = 'config.json'
+
+  def setCustomConfigDir(self, config_dir):
+    # Override the configuration directory where the docker configuration
+    # JSON is searched for
+    if not os.path.isdir(config_dir):
+      raise Exception("Attempting to override docker configuration directory" +\
+      " to invalid directory: {}".format(config_dir))
+    self._config_dir = config_dir
 
   def Resolve(self, name):
     # TODO(user): Consider supporting .dockercfg, which was used prior
     # to Docker 1.7 and consisted of just the contents of 'auths' below.
     logging.info('Loading Docker credentials for repository %r', str(name))
-    config_file = os.path.join(_GetConfigDirectory(), 'config.json')
+    config_file = None
+    if self._config_dir is not None:
+      config_file = os.path.join(self._config_dir, self._config_file)
+    else:
+      config_file = os.path.join(_GetConfigDirectory(), self._config_file)
     try:
       with io.open(config_file, u'r', encoding='utf8') as reader:
         cfg = json.loads(reader.read())

--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -241,8 +241,8 @@ class _DefaultKeychain(Keychain):
     # Override the configuration directory where the docker configuration
     # JSON is searched for
     if not os.path.isdir(config_dir):
-      raise Exception("Attempting to override docker configuration directory" +\
-      " to invalid directory: {}".format(config_dir))
+      raise Exception('Attempting to override docker configuration directory'
+                      ' to invalid directory: {}'.format(config_dir))
     self._config_dir = config_dir
 
   def Resolve(self, name):

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -57,6 +57,12 @@ parser.add_argument(
     help=('Which platform image to pull for multi-platform manifest lists. '
           'Formatted as os/arch.'))
 
+parser.add_argument(
+    '--client-config-dir',
+    action='store',
+    help='The path to the directory where the client configuration files are '
+    'located. Overiddes the value from DOCKER_CONFIG')
+
 _THREADS = 8
 
 
@@ -79,6 +85,9 @@ def main():
     name = docker_name.Digest(args.name)
   else:
     name = docker_name.Tag(args.name)
+
+  if args.client_config_dir is not None:
+    docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
 
   # OCI Image Manifest is compatible with Docker Image Manifest Version 2,
   # Schema 2. We indicate support for both formats by passing both media types

--- a/tools/fast_puller_.py
+++ b/tools/fast_puller_.py
@@ -86,6 +86,12 @@ def main():
   else:
     name = docker_name.Tag(args.name)
 
+  # If the user provided a client config directory, instruct the keychain
+  # resolver to use it to look for the docker client config
+  if args.client_config_dir is not None:
+    docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
+
+
   if args.client_config_dir is not None:
     docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
 

--- a/tools/fast_pusher_.py
+++ b/tools/fast_pusher_.py
@@ -130,9 +130,6 @@ def main():
     logging.fatal('Either --config or --tarball must be specified.')
     sys.exit(1)
 
-  if args.client_config_dir is not None:
-    docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
-
   # If config is specified, use that.  Otherwise, fallback on reading
   # the config from the tarball.
   config = args.config
@@ -153,6 +150,11 @@ def main():
   if len(args.digest or []) != len(args.layer or []):
     logging.fatal('--digest and --layer must have matching lengths.')
     sys.exit(1)
+
+  # If the user provided a client config directory, instruct the keychain
+  # resolver to use it to look for the docker client config
+  if args.client_config_dir is not None:
+    docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
 
   retry_factory = retry.Factory()
   retry_factory = retry_factory.WithSourceTransportCallable(httplib2.Http)

--- a/tools/fast_pusher_.py
+++ b/tools/fast_pusher_.py
@@ -78,6 +78,12 @@ parser.add_argument(
           'to make in the provided --name, e.g. {BUILD_USER}'))
 
 parser.add_argument(
+    '--client-config-dir',
+    action='store',
+    help='The path to the directory where the client configuration files are '
+    'located. Overiddes the value from DOCKER_CONFIG')
+
+parser.add_argument(
     '--oci', action='store_true', help='Push the image with an OCI Manifest.')
 
 _THREADS = 8
@@ -123,6 +129,9 @@ def main():
   if not args.config and not args.tarball:
     logging.fatal('Either --config or --tarball must be specified.')
     sys.exit(1)
+
+  if args.client_config_dir is not None:
+    docker_creds.DefaultKeychain.setCustomConfigDir(args.client_config_dir)
 
   # If config is specified, use that.  Otherwise, fallback on reading
   # the config from the tarball.


### PR DESCRIPTION
@nlopezgi @pcj This Mostly duplicates #112 while also adding the arg to the puller. This arg is expected to be used by rules_docker to allow rules to change the directory the docker client configuration directory if needed