### PR TITLE
upver httplib2==0.12.0 to support custom certs path

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -20,9 +20,8 @@ def repositories():
 
     http_archive(
         name = "httplib2",
-        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
-        sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
-        strip_prefix = "httplib2-0.11.3/python2/httplib2/",
+        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.12.0",
+        strip_prefix = "httplib2-0.12.0/python2/httplib2/",
         type = "tar.gz",
         build_file_content = """
 py_library(


### PR DESCRIPTION
`httplib2==0.12.0` supports reading the certs from `HTTPLIB2_CA_CERTS`.
This env variable can be injected using `action_env`. This is needed to
pull/push from registries with custom certs.