### PR TITLE
Fix encoding bug when calling Popen.communicate

### DIFF
--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -164,7 +164,8 @@ class Helper(Basic):
 
     # Some keychains expect a scheme:
     # https://github.com/bazelbuild/rules_docker/issues/111
-    stdout = p.communicate(input='https://' + self._registry)[0]
+    url = 'https://' + self._registry
+    stdout = p.communicate(input=url.encode('utf-8'))[0]
     if stdout.strip() == _MAGIC_NOT_FOUND_MESSAGE:
       # Use empty auth when no auth is found.
       logging.info('Credentials not found, falling back to anonymous auth.')


### PR DESCRIPTION
`communicate` expects a bytes-like thing for `input`; was erroring out with
```
memoryview: a bytes-like object is required, not 'str'
```
Depends on the destination repo whether that codepath is hit or not though so doesn't happen every time.