### PR TITLE
Update subpar dependency (2018-03-07)

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -93,5 +93,5 @@ py_library(
     git_repository(
         name = "subpar",
         remote = "https://github.com/google/subpar",
-        commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
+        commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0", # 2019-03-07
     )

--- a/def.bzl
+++ b/def.bzl
@@ -93,5 +93,5 @@ py_library(
     git_repository(
         name = "subpar",
         remote = "https://github.com/google/subpar",
-        commit = "07ff5feb7c7b113eea593eb6ec50b51099cf0261",
+        commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
     )


### PR DESCRIPTION
This updates the subpar dependency to 0356bef3fbbabec5f0e196ecfacdeb6db62d48c0, which works with `--incompatible_remove_old_python_version_api` in Bazel 0.23.