### PR TITLE
Canonicalize subpar dependency.

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -94,4 +94,5 @@ py_library(
         name = "subpar",
         remote = "https://github.com/google/subpar",
         commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",  # 2019-03-07
+        shallow_since = "1551997562 -0500"
     )


### PR DESCRIPTION
Fix for a warning that is a minor usance, and is non-actionable for repositories that depend on these rules.

See: https://github.com/bazelbuild/bazel/issues/8222