### PR TITLE
Fix travis

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,7 +23,6 @@ py_library(
         "transport/**/*.py",
     ]),
     deps = [
-        "@concurrent//:concurrent",
         "@httplib2//:httplib2",
         "@oauth2client//:oauth2client",
         "@six//:six",

--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -164,7 +164,8 @@ class Helper(Basic):
 
     # Some keychains expect a scheme:
     # https://github.com/bazelbuild/rules_docker/issues/111
-    stdout = p.communicate(input='https://' + self._registry)[0]
+    stdout = p.communicate(
+        input=('https://' + self._registry).encode('utf-8'))[0]
     if stdout.strip() == _MAGIC_NOT_FOUND_MESSAGE:
       # Use empty auth when no auth is found.
       logging.info('Credentials not found, falling back to anonymous auth.')

--- a/client/v2_2/append_.py
+++ b/client/v2_2/append_.py
@@ -65,7 +65,7 @@ class Layer(docker_image.DockerImage):
       self._blob_sum = docker_digest.SHA256(self._blob)
       manifest['layers'].append({
           'digest': self._blob_sum,
-          'mediaType': docker_http.MANIFEST_SCHEMA2_MIME,
+          'mediaType': docker_http.LAYER_MIME,
           'size': len(self._blob),
       })
       if not diff_id:

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -361,7 +361,7 @@ class Transport(object):
 
     # If the first request fails on a 401 Unauthorized, then refresh the
     # Bearer token and retry, if the authentication mode is bearer.
-    for retry in [self._authentication == _BEARER, False]:
+    for retry_unauthorized in [self._authentication == _BEARER, False]:
       # self._creds may be changed by self._Refresh(), so do
       # not hoist this.
       headers = {
@@ -385,11 +385,12 @@ class Transport(object):
       resp, content = self._transport.request(
           url, method, body=body, headers=headers)
 
-      if resp.status != six.moves.http_client.UNAUTHORIZED:
-        break
-      elif retry:
+      if (retry_unauthorized and
+          resp.status == six.moves.http_client.UNAUTHORIZED):
         # On Unauthorized, refresh the credential and retry.
         self._Refresh()
+        continue
+      break
 
     if resp.status not in accepted_codes:
       # Use the content returned by GCR as the error message.

--- a/client/v2_2/save_.py
+++ b/client/v2_2/save_.py
@@ -219,7 +219,7 @@ def fast(image,
     future_to_params[f] = config_file
 
     executor.submit(write_file, os.path.join(directory, 'digest'),
-                    lambda unused: image.digest(), 'unused')
+                    lambda unused: image.digest().encode('utf8'), 'unused')
     executor.submit(write_file, os.path.join(directory, 'manifest.json'),
                     lambda unused: image.manifest().encode('utf8'),
                     'unused')
@@ -308,7 +308,7 @@ def uncompressed(image,
     future_to_params[f] = config_file
 
     executor.submit(write_file, os.path.join(directory, 'digest'),
-                    lambda unused: image.digest(), 'unused')
+                    lambda unused: image.digest().encode('utf8'), 'unused')
     executor.submit(write_file, os.path.join(directory, 'manifest.json'),
                     lambda unused: image.manifest().encode('utf8'),
                     'unused')

--- a/def.bzl
+++ b/def.bzl
@@ -20,9 +20,9 @@ def repositories():
 
     http_archive(
         name = "httplib2",
-        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.11.3",
-        sha256 = "d9f568c183d1230f271e9c60bd99f3f2b67637c3478c9068fea29f7cca3d911f",
-        strip_prefix = "httplib2-0.11.3/python2/httplib2/",
+        url = "https://codeload.github.com/httplib2/httplib2/tar.gz/v0.17.0",
+        sha256 = "556aa045aefeed3fd58a003251c94627e077ab0732758e5178a0074d9c75a68b",
+        strip_prefix = "httplib2-0.17.0/python3/httplib2/",
         type = "tar.gz",
         build_file_content = """
 py_library(
@@ -74,24 +74,17 @@ py_library(
 )""",
     )
 
-    # Used for parallel execution in containerregistry
+    # For subpar.
     http_archive(
-        name = "concurrent",
-        url = "https://codeload.github.com/agronholm/pythonfutures/tar.gz/3.0.5",
-        sha256 = "a7086ddf3c36203da7816f7e903ce43d042831f41a9705bc6b4206c574fcb765",
-        strip_prefix = "pythonfutures-3.0.5/concurrent/",
-        type = "tar.gz",
-        build_file_content = """
-py_library(
-   name = "concurrent",
-   srcs = glob(["**/*.py"]),
-   visibility = ["//visibility:public"]
-)""",
+        name = "rules_python",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
+        sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
     )
 
     # For packaging python tools.
     git_repository(
         name = "subpar",
         remote = "https://github.com/google/subpar",
-        commit = "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",  # 2019-03-07
+        commit = "9fae6b63cfeace2e0fb93c9c1ebdc28d3991b16f",  # 2019-08-14
+        shallow_since = "1565833028 -0400",
     )

--- a/puller_test.sh
+++ b/puller_test.sh
@@ -79,8 +79,8 @@ function test_image() {
 
   test_puller "${image}"
 
-  test_base "${image}" python2.7 python:2.7
-  test_base "${image}" python2.7 gcr.io/cloud-builders/bazel
+  test_base "${image}" python3 python:3
+  test_base "${image}" python3 gcr.io/cloud-builders/bazel
 }
 
 function test_puller_with_cache() {
@@ -111,8 +111,8 @@ function test_puller_with_cache() {
   local pull_end=$(date +%s)
   timing=$(($pull_end-$pull_start))
 
-  test_base "${image}" python2.7 python:2.7
-  test_base "${image}" python2.7 gcr.io/cloud-builders/bazel
+  test_base "${image}" python3 python:3
+  test_base "${image}" python3 gcr.io/cloud-builders/bazel
 }
 
  function clear_cache_directory() {
@@ -150,7 +150,9 @@ test_image quay.io/coreos/etcd:latest
 # As of this CL, the official python:2.7 image uses 2.7.13.
 # We cannot test this with the gcr.io/cloud-builders/bazel image because
 # it is based on the latest Ubuntu LTS release (14.04) which uses 2.7.6
-test_base registry.gitlab.com/mattmoor/test-project/image:latest python2.7 python:2.7
+# TODO: Error pulling and saving image registry.gitlab.com/mattmoor/test-project/image:latest: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)
+# test_base registry.gitlab.com/mattmoor/test-project/image:latest python3 python:3
+
 
 # Test pulling by digest
 test_image gcr.io/google-containers/pause@sha256:9ce5316f9752b8347484ab0f6778573af15524124d52b93230b9a0dcc987e73e

--- a/tools/fast_flatten_.py
+++ b/tools/fast_flatten_.py
@@ -94,7 +94,7 @@ def main():
       layers=layers,
       uncompressed_layers=uncompressed_layers,
       legacy_base=args.tarball) as v2_2_img:
-    with tarfile.open(args.filesystem, 'w:') as tar:
+    with tarfile.open(args.filesystem, 'w:', encoding='utf-8') as tar:
       v2_2_image.extract(v2_2_img, tar)
 
     with open(args.metadata, 'w') as f:


### PR DESCRIPTION
Fixes https://github.com/google/containerregistry/issues/42
Fixes https://github.com/google/containerregistry/issues/152
Fixes https://github.com/google/containerregistry/issues/153

There's a lot of work that needs to go into this -- mostly around migrating off of httplib2 for https://github.com/google/containerregistry/issues/150 and https://github.com/google/containerregistry/issues/97, but this is a decent start.

Ideally most folks would migrate over to go-containerregistry, but I understand that rewriting all the python code in the world is impractical.