### PR TITLE
Switch to using module-level loggers

### DIFF
--- a/client/v1/docker_session_.py
+++ b/client/v1/docker_session_.py
@@ -33,6 +33,8 @@ from containerregistry.client.v1 import docker_image
 import httplib2
 import six.moves.http_client
 
+_LOGGER = logging.getLogger('containerregistry.client.docker_session')
+
 
 class Push(object):
   """Push encapsulates a go/docker:push session."""
@@ -83,7 +85,7 @@ class Push(object):
     # TODO(user): Consider also supporting cookies, which are
     # used by Quay.io for authenticated sessions.
 
-    logging.info('Initiated upload of: %s', self._name)
+    _LOGGER.info('Initiated upload of: %s', self._name)
     return self
 
   def _exists(self, layer_id):
@@ -138,7 +140,7 @@ class Push(object):
                   layer_id):
     """Upload a single layer, after checking whether it exists already."""
     if self._exists(layer_id):
-      logging.info('Layer %s exists, skipping', layer_id)
+      _LOGGER.info('Layer %s exists, skipping', layer_id)
       return
 
     # TODO(user): This ordering is consistent with the docker client,
@@ -148,7 +150,7 @@ class Push(object):
     self._put_json(image, layer_id)
     self._put_layer(image, layer_id)
     self._put_checksum(image, layer_id)
-    logging.info('Layer %s pushed.', layer_id)
+    _LOGGER.info('Layer %s pushed.', layer_id)
 
   def upload(self, image):
     """Upload the layers of the given image.
@@ -187,7 +189,7 @@ class Push(object):
 
   def __exit__(self, exception_type, unused_value, unused_traceback):
     if exception_type:
-      logging.error('Error during upload of: %s', self._name)
+      _LOGGER.error('Error during upload of: %s', self._name)
       return
 
     # This should complete the upload by issuing:
@@ -199,4 +201,4 @@ class Push(object):
     # to complete the transaction, with basic auth talking to registry.
     self._put_images()
 
-    logging.info('Finished upload of: %s', self._name)
+    _LOGGER.info('Finished upload of: %s', self._name)

--- a/client/v2/docker_session_.py
+++ b/client/v2/docker_session_.py
@@ -31,6 +31,8 @@ import httplib2
 import six.moves.http_client
 import six.moves.urllib.parse
 
+_LOGGER = logging.getLogger('containerregistry.client.docker_session')
+
 
 def _tag_or_digest(name):
   if isinstance(name, docker_name.Tag):
@@ -133,7 +135,7 @@ class Push(object):
     mounted, location = self._start_upload(digest, self._mount)
 
     if mounted:
-      logging.info('Layer %s mounted.', digest)
+      _LOGGER.info('Layer %s mounted.', digest)
       return
 
     location = self._add_digest(location, digest)
@@ -149,7 +151,7 @@ class Push(object):
     mounted, location = self._start_upload(digest, self._mount)
 
     if mounted:
-      logging.info('Layer %s mounted.', digest)
+      _LOGGER.info('Layer %s mounted.', digest)
       return
 
     location = self._get_absolute_url(location)
@@ -258,11 +260,11 @@ class Push(object):
   def _upload_one(self, image, digest):
     """Upload a single layer, after checking whether it exists already."""
     if self._blob_exists(digest):
-      logging.info('Layer %s exists, skipping', digest)
+      _LOGGER.info('Layer %s exists, skipping', digest)
       return
 
     self._put_blob(image, digest)
-    logging.info('Layer %s pushed.', digest)
+    _LOGGER.info('Layer %s pushed.', digest)
 
   def upload(self, image):
     """Upload the layers of the given image.
@@ -275,11 +277,11 @@ class Push(object):
     if self._manifest_exists(image):
       if isinstance(self._name, docker_name.Tag):
         if self._remote_tag_digest() == image.digest():
-          logging.info('Tag points to the right manifest, skipping push.')
+          _LOGGER.info('Tag points to the right manifest, skipping push.')
           return
-        logging.info('Manifest exists, skipping blob uploads and pushing tag.')
+        _LOGGER.info('Manifest exists, skipping blob uploads and pushing tag.')
       else:
-        logging.info('Manifest exists, skipping upload.')
+        _LOGGER.info('Manifest exists, skipping upload.')
     elif self._threads == 1:
       for digest in image.blob_set():
         self._upload_one(image, digest)
@@ -302,9 +304,9 @@ class Push(object):
 
   def __exit__(self, exception_type, unused_value, unused_traceback):
     if exception_type:
-      logging.error('Error during upload of: %s', self._name)
+      _LOGGER.error('Error during upload of: %s', self._name)
       return
-    logging.info('Finished upload of: %s', self._name)
+    _LOGGER.info('Finished upload of: %s', self._name)
 
 
 # pylint: disable=invalid-name

--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -31,6 +31,8 @@ import httplib2
 import six.moves.http_client
 import six.moves.urllib.parse
 
+_LOGGER = logging.getLogger('containerregistry.client.docker_session')
+
 
 def _tag_or_digest(name):
   if isinstance(name, docker_name.Tag):
@@ -141,7 +143,7 @@ class Push(object):
     mounted, location = self._start_upload(digest, self._mount)
 
     if mounted:
-      logging.info('Layer %s mounted.', digest)
+      _LOGGER.info('Layer %s mounted.', digest)
       return
 
     location = self._add_digest(location, digest)
@@ -157,7 +159,7 @@ class Push(object):
     mounted, location = self._start_upload(digest, self._mount)
 
     if mounted:
-      logging.info('Layer %s mounted.', digest)
+      _LOGGER.info('Layer %s mounted.', digest)
       return
 
     location = self._get_absolute_url(location)
@@ -277,11 +279,11 @@ class Push(object):
   def _upload_one(self, image, digest):
     """Upload a single layer, after checking whether it exists already."""
     if self._blob_exists(digest):
-      logging.info('Layer %s exists, skipping', digest)
+      _LOGGER.info('Layer %s exists, skipping', digest)
       return
 
     self._put_blob(image, digest)
-    logging.info('Layer %s pushed.', digest)
+    _LOGGER.info('Layer %s pushed.', digest)
 
   def upload(self,
              image,
@@ -297,11 +299,11 @@ class Push(object):
     if self._manifest_exists(image):
       if isinstance(self._name, docker_name.Tag):
         if self._remote_tag_digest(image) == image.digest():
-          logging.info('Tag points to the right manifest, skipping push.')
+          _LOGGER.info('Tag points to the right manifest, skipping push.')
           return
-        logging.info('Manifest exists, skipping blob uploads and pushing tag.')
+        _LOGGER.info('Manifest exists, skipping blob uploads and pushing tag.')
       else:
-        logging.info('Manifest exists, skipping upload.')
+        _LOGGER.info('Manifest exists, skipping upload.')
     elif isinstance(image, image_list.DockerImageList):
       for _, child in image:
         # TODO(user): Refactor so that the threadpool is shared.
@@ -329,9 +331,9 @@ class Push(object):
 
   def __exit__(self, exception_type, unused_value, unused_traceback):
     if exception_type:
-      logging.error('Error during upload of: %s', self._name)
+      _LOGGER.error('Error during upload of: %s', self._name)
       return
-    logging.info('Finished upload of: %s', self._name)
+    _LOGGER.info('Finished upload of: %s', self._name)
 
 
 # pylint: disable=invalid-name

--- a/transport/retry_.py
+++ b/transport/retry_.py
@@ -23,6 +23,7 @@ from containerregistry.transport import nested
 import httplib2
 import six.moves.http_client
 
+_LOGGER = logging.getLogger('containerregistry.transport.retry')
 DEFAULT_SOURCE_TRANSPORT_CALLABLE = httplib2.Http
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_BACKOFF_FACTOR = 0.5
@@ -103,7 +104,7 @@ class RetryTransport(nested.NestedTransport):
         if retries >= self._max_retries or not self._should_retry(err):
           raise
 
-        logging.error('Retrying after exception %s.', err)
+        _LOGGER.error('Retrying after exception %s.', err)
         retries += 1
         time.sleep(self._backoff_factor * (2**retries))
         continue


### PR DESCRIPTION
We have notifications setup on all logging.errors, but we don't want to be notified for retries (we will be notified if the retries fail, as it still raises an exception). By switching to a non-root logger, it allows us to disable notifications on this particular logger, but doesn't change the default behavior.